### PR TITLE
Allow physical properties of `overflow`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -107,7 +107,9 @@
 			}
 		},
 		"node_modules/@csstools/css-parser-algorithms": {
-			"version": "2.5.0",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.6.1.tgz",
+			"integrity": "sha512-ubEkAaTfVZa+WwGhs5jbo5Xfqpeaybr/RvWzvFxRs4jfq16wH8l8Ty/QEEpINxll4xhuGfdMbipRyz5QZh9+FA==",
 			"funding": [
 				{
 					"type": "github",
@@ -118,16 +120,17 @@
 					"url": "https://opencollective.com/csstools"
 				}
 			],
-			"license": "MIT",
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
 			"peerDependencies": {
-				"@csstools/css-tokenizer": "^2.2.3"
+				"@csstools/css-tokenizer": "^2.2.4"
 			}
 		},
 		"node_modules/@csstools/css-tokenizer": {
-			"version": "2.2.3",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.2.4.tgz",
+			"integrity": "sha512-PuWRAewQLbDhGeTvFuq2oClaSCKPIBmHyIobCV39JHRYN0byDcUWJl5baPeNUcqrjtdMNqFooE0FGl31I3JOqw==",
 			"funding": [
 				{
 					"type": "github",
@@ -138,13 +141,14 @@
 					"url": "https://opencollective.com/csstools"
 				}
 			],
-			"license": "MIT",
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			}
 		},
 		"node_modules/@csstools/media-query-list-parser": {
-			"version": "2.1.7",
+			"version": "2.1.9",
+			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.9.tgz",
+			"integrity": "sha512-qqGuFfbn4rUmyOB0u8CVISIp5FfJ5GAR3mBrZ9/TKndHakdnm6pY0L/fbLcpPnrzwCyyTEZl1nUcXAYHEWneTA==",
 			"funding": [
 				{
 					"type": "github",
@@ -155,17 +159,18 @@
 					"url": "https://opencollective.com/csstools"
 				}
 			],
-			"license": "MIT",
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
 			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^2.5.0",
-				"@csstools/css-tokenizer": "^2.2.3"
+				"@csstools/css-parser-algorithms": "^2.6.1",
+				"@csstools/css-tokenizer": "^2.2.4"
 			}
 		},
 		"node_modules/@csstools/selector-specificity": {
-			"version": "3.0.1",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.0.3.tgz",
+			"integrity": "sha512-KEPNw4+WW5AVEIyzC80rTbWEUatTW2lXpN8+8ILC8PiPeWPjwUzrPZDIOZ2wwqDmeqOYTdSGyL3+vE5GC3FB3Q==",
 			"funding": [
 				{
 					"type": "github",
@@ -176,12 +181,20 @@
 					"url": "https://opencollective.com/csstools"
 				}
 			],
-			"license": "MIT-0",
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
 			"peerDependencies": {
 				"postcss-selector-parser": "^6.0.13"
+			}
+		},
+		"node_modules/@dual-bundle/import-meta-resolve": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.0.0.tgz",
+			"integrity": "sha512-ZKXyJeFAzcpKM2kk8ipoGIPUqx9BX52omTGnfwjJvxOCaZTM2wtDK7zN0aIgPRbT9XYAlha0HtmZ+XKteuh0Gw==",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/@es-joy/jsdoccomment": {
@@ -3014,8 +3027,9 @@
 			}
 		},
 		"node_modules/known-css-properties": {
-			"version": "0.29.0",
-			"license": "MIT"
+			"version": "0.30.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.30.0.tgz",
+			"integrity": "sha512-VSWXYUnsPu9+WYKkfmJyLKtIvaRJi1kXUqVmBACORXZQxT5oZDsoZ2vQP+bQFDnWtpI/4eq3MLoRMjI2fnLzTQ=="
 		},
 		"node_modules/lcid": {
 			"version": "3.1.1",
@@ -3557,7 +3571,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.35",
+			"version": "8.4.38",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+			"integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -3572,11 +3588,10 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
-			"license": "MIT",
 			"dependencies": {
 				"nanoid": "^3.3.7",
 				"picocolors": "^1.0.0",
-				"source-map-js": "^1.0.2"
+				"source-map-js": "^1.2.0"
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
@@ -3914,8 +3929,9 @@
 			}
 		},
 		"node_modules/source-map-js": {
-			"version": "1.0.2",
-			"license": "BSD-3-Clause",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+			"integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -4079,14 +4095,15 @@
 			}
 		},
 		"node_modules/stylelint": {
-			"version": "16.2.1",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.2.1.tgz",
-			"integrity": "sha512-SfIMGFK+4n7XVAyv50CpVfcGYWG4v41y6xG7PqOgQSY8M/PgdK0SQbjWFblxjJZlN9jNq879mB4BCZHJRIJ1hA==",
+			"version": "16.3.1",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.3.1.tgz",
+			"integrity": "sha512-/JOwQnBvxEKOT2RtNgGpBVXnCSMBgKOL2k7w0K52htwCyJls4+cHvc4YZgXlVoAZS9QJd2DgYAiRnja96pTgxw==",
 			"dependencies": {
-				"@csstools/css-parser-algorithms": "^2.5.0",
-				"@csstools/css-tokenizer": "^2.2.3",
-				"@csstools/media-query-list-parser": "^2.1.7",
-				"@csstools/selector-specificity": "^3.0.1",
+				"@csstools/css-parser-algorithms": "^2.6.1",
+				"@csstools/css-tokenizer": "^2.2.4",
+				"@csstools/media-query-list-parser": "^2.1.9",
+				"@csstools/selector-specificity": "^3.0.2",
+				"@dual-bundle/import-meta-resolve": "^4.0.0",
 				"balanced-match": "^2.0.0",
 				"colord": "^2.9.3",
 				"cosmiconfig": "^9.0.0",
@@ -4100,19 +4117,19 @@
 				"globby": "^11.1.0",
 				"globjoin": "^0.1.4",
 				"html-tags": "^3.3.1",
-				"ignore": "^5.3.0",
+				"ignore": "^5.3.1",
 				"imurmurhash": "^0.1.4",
 				"is-plain-object": "^5.0.0",
-				"known-css-properties": "^0.29.0",
+				"known-css-properties": "^0.30.0",
 				"mathml-tag-names": "^2.1.3",
-				"meow": "^13.1.0",
+				"meow": "^13.2.0",
 				"micromatch": "^4.0.5",
 				"normalize-path": "^3.0.0",
 				"picocolors": "^1.0.0",
-				"postcss": "^8.4.33",
+				"postcss": "^8.4.38",
 				"postcss-resolve-nested-selector": "^0.1.1",
 				"postcss-safe-parser": "^7.0.0",
-				"postcss-selector-parser": "^6.0.15",
+				"postcss-selector-parser": "^6.0.16",
 				"postcss-value-parser": "^4.2.0",
 				"resolve-from": "^5.0.0",
 				"string-width": "^4.2.3",
@@ -4801,7 +4818,7 @@
 				"stylelint-config-standard": "^36.0.0"
 			},
 			"devDependencies": {
-				"stylelint": "^16.2.1"
+				"stylelint": "^16.3.1"
 			},
 			"peerDependencies": {
 				"stylelint": "^16.2.1"

--- a/packages/stylelint/__tests__/invalid/rules.css
+++ b/packages/stylelint/__tests__/invalid/rules.css
@@ -51,7 +51,6 @@
 	height: 0;
 	min-height: 0;
 	max-height: 0;
-	overflow-x: auto;
 	overscroll-behavior-x: auto;
 }
 

--- a/packages/stylelint/package.json
+++ b/packages/stylelint/package.json
@@ -24,10 +24,10 @@
 		"stylelint-config-standard": "^36.0.0"
 	},
 	"devDependencies": {
-		"stylelint": "^16.2.1"
+		"stylelint": "^16.3.1"
 	},
 	"peerDependencies": {
-		"stylelint": "^16.2.1"
+		"stylelint": "^16.3.1"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/stylelint/stylelint.config.js
+++ b/packages/stylelint/stylelint.config.js
@@ -158,8 +158,6 @@ export default {
 				'height',
 				'min-height',
 				'max-height',
-				'overflow-x',
-				'overflow-y',
 				'overscroll-behavior-x',
 				'overscroll-behavior-y',
 			],


### PR DESCRIPTION
Logical  properties of `overflow` is only supported by Firefox.

- [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-inline#browser_compatibility)
- [Can I use...](https://caniuse.com/mdn-css_properties_overflow-inline)