### PR TITLE
Enable `@typescript-eslint/strict-boolean-expressions` rule

### DIFF
--- a/packages/eslint/README.md
+++ b/packages/eslint/README.md
@@ -10,7 +10,13 @@ ESLint configuration file used on my personal website ([w0s.jp](https://github.c
 - [eslint:recommended](https://eslint.org/docs/latest/user-guide/configuring/configuration-files#using-eslintrecommended)
 - [eslint-config-airbnb-base](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base)
   - [eslint-plugin-import](https://github.com/import-js/eslint-plugin-import)
-- [plugin:@typescript-eslint/recommended](https://github.com/typescript-eslint/typescript-eslint/tree/main/packages/eslint-plugin) (TypeScript file only)
+- [plugin:jsdoc/recommended](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/src/index.js)
+
+### TypeScript file
+
+- [plugin:@typescript-eslint/strict-type-checked](https://typescript-eslint.io/users/configs/#strict-type-checked)
+- [plugin:@typescript-eslint/stylistic-type-checked](https://typescript-eslint.io/users/configs/#stylistic-type-checked)
+- [plugin:jsdoc/recommended-typescript](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/src/index.js)
 
 ## `plugins`
 

--- a/packages/eslint/index.js
+++ b/packages/eslint/index.js
@@ -29,6 +29,12 @@ module.exports = {
 				'@typescript-eslint/no-unsafe-call': 'off',
 				'@typescript-eslint/no-unsafe-member-access': 'off',
 				'@typescript-eslint/no-unsafe-return': 'off',
+				'@typescript-eslint/strict-boolean-expressions': [
+					'error',
+					{
+						allowNullableBoolean: true,
+					},
+				],
 			},
 		},
 		{


### PR DESCRIPTION
[strict-boolean-expressions](https://typescript-eslint.io/rules/strict-boolean-expressions)