### PR TITLE
Enable `erasableSyntaxOnly` (Node.js Type stripping)

### DIFF
--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -23,6 +23,7 @@
 		"newLine": "lf",
 
 		/* Interop Constraints */
+		"erasableSyntaxOnly": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
 		"verbatimModuleSyntax": true,


### PR DESCRIPTION
[Type stripping | Node.js v24.7.0 Documentation](https://nodejs.org/api/typescript.html#type-stripping)