### PR TITLE
Enable `@typescript-eslint/no-extraneous-class` rule

### DIFF
--- a/packages/eslint/eslint.config.js
+++ b/packages/eslint/eslint.config.js
@@ -56,7 +56,6 @@ export default defineConfig(
 				},
 			],
 			'import/no-unresolved': 'off',
-			'@typescript-eslint/no-extraneous-class': 'off',
 			'@typescript-eslint/no-unused-vars': [
 				'error',
 				{


### PR DESCRIPTION
fix #107