### PR TITLE
Remove `alwaysStrict` option

### DIFF
--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -3,7 +3,6 @@
 		/* Type Checking */
 		"allowUnreachableCode": false,
 		"allowUnusedLabels": false,
-		"alwaysStrict": false,
 		"exactOptionalPropertyTypes": true,
 		"noFallthroughCasesInSwitch": true,
 		"noImplicitOverride": true,


### PR DESCRIPTION
Because `--alwaysStrict false` will be [deprecated in TypeScript 6.0](https://devblogs.microsoft.com/typescript/announcing-typescript-6-0-beta/#deprecated:---alwaysstrict-false).
